### PR TITLE
Async event

### DIFF
--- a/src/event/src/__test__/event.test.ts
+++ b/src/event/src/__test__/event.test.ts
@@ -56,6 +56,12 @@ describe("Event System Unit Tests", () => {
                 (_data: EventsTypes) => {},
             ),
         ).toStrictEqual(CALLBACK_NEWLENGTH_NULL);
+        expect(
+            e.unsubscribeAllCallback(
+                Events.GameStart,
+                (_data: EventsTypes) => {},
+            ),
+        ).toStrictEqual(CALLBACK_NEWLENGTH_NULL);
     });
 
     it("Subscribe", () => {
@@ -107,7 +113,7 @@ describe("Event System Unit Tests", () => {
         const l2 = "Game Started yayy";
         const l3 = "This is the final loading";
 
-        const c1 = async (data: GameStart) => {
+        const c1 = (data: GameStart) => {
             console.log(l1);
         };
         const c2 = (data: GameStart) => {
@@ -119,7 +125,7 @@ describe("Event System Unit Tests", () => {
 
         e.subscribe(Events.GameEnd, (data: GameEnd) => {});
         e.subscribe(Events.GameStart, c1);
-        e.subscribe(Events.GameStart, c2);
+        e.subscribe(Events.GameStart, c2, undefined);
         e.subscribe(Events.GameStart, c3);
 
         expect(e.hasCallback(Events.GameEnd)).toBe(true);
@@ -219,7 +225,7 @@ describe("Event System Unit Tests", () => {
         e.clear(Events.GameStart);
         expect(e.getNumberOfCallbacks(Events.GameStart)).toBe(0);
         e.subscribe(Events.GameStart, c1);
-        e.subscribe(Events.GameStart, c2, true);
+        e.subscribe(Events.GameStart, c2);
         e.subscribe(Events.GameStart, c3);
         expect(e.getNumberOfCallbacks(Events.GameStart)).toBe(3);
 
@@ -255,9 +261,9 @@ describe("Event System Unit Tests", () => {
         e.subscribe(Events.GameStart, c3);
 
         e.subscribeIndex(Events.GameStart, 10, c3);
-        e.subscribeIndex(Events.GameStart, 3, c2);
-        e.subscribeIndex(Events.GameStart, 4, c1);
-        e.subscribeIndex(Events.GameStart, 1, c1);
+        e.subscribeIndex(Events.GameStart, 3, c2, undefined);
+        e.subscribeIndex(Events.GameStart, 4, c1, false);
+        e.subscribeIndex(Events.GameStart, 1, c1, null);
 
         e.throw(Events.GameStart, {
             ether: 1234,
@@ -334,7 +340,56 @@ describe("Event System Unit Tests", () => {
         ).toStrictEqual(CALLBACK_NEWLENGTH_NULL);
     });
 
-    it("unsubscribeAllCallback", async () => {});
+    it("unsubscribeAllCallback", async () => {
+        const l1 = "First checkss...";
+        const l2 = "Game Started yayy";
+        const l3 = "This is the final loading";
+
+        const c1 = (data: GameStart) => {
+            console.log(l1);
+        };
+        const c2 = (data: GameStart) => {
+            console.log(l2);
+        };
+        const c3 = (data: GameStart) => {
+            console.log(l3);
+        };
+
+        e.subscribe(Events.GameStart, c1);
+        e.subscribe(Events.GameStart, c2);
+        e.subscribe(Events.GameStart, c3);
+        e.subscribe(Events.GameStart, c1);
+        e.subscribe(Events.GameStart, c2);
+        e.subscribe(Events.GameStart, c3);
+
+        e.throw(Events.GameStart, {
+            ether: 1234,
+            timestamp: 156790,
+            playerId: "sjdDRRRR",
+        });
+
+        expect(consoleSpy).toHaveBeenCalledTimes(6);
+        expect(consoleSpy).toHaveBeenNthCalledWith(1, l1);
+        expect(consoleSpy).toHaveBeenNthCalledWith(2, l2);
+        expect(consoleSpy).toHaveBeenNthCalledWith(3, l3);
+        expect(consoleSpy).toHaveBeenNthCalledWith(4, l1);
+        expect(consoleSpy).toHaveBeenNthCalledWith(5, l2);
+        expect(consoleSpy).toHaveBeenNthCalledWith(6, l3);
+
+        e.unsubscribeAllCallback(Events.GameStart, c3);
+
+        e.throw(Events.GameStart, {
+            ether: 1234,
+            timestamp: 156790,
+            playerId: "sjdDRRRR",
+        });
+
+        expect(consoleSpy).toHaveBeenCalledTimes(10);
+        expect(consoleSpy).toHaveBeenNthCalledWith(7, l1);
+        expect(consoleSpy).toHaveBeenNthCalledWith(8, l2);
+        expect(consoleSpy).toHaveBeenNthCalledWith(9, l1);
+        expect(consoleSpy).toHaveBeenNthCalledWith(10, l2);
+    });
 });
 
 function sleep(ms: number) {

--- a/src/event/src/__test__/event.test.ts
+++ b/src/event/src/__test__/event.test.ts
@@ -37,10 +37,10 @@ describe("Event System Unit Tests", () => {
                 byPlayerId: "",
             }),
         ).toBe(null);
-        expect(e.unsubscribe(Events.PlayerConnection, 0)).toStrictEqual(
+        expect(e.unsubscribeIndex(Events.PlayerConnection, 0)).toStrictEqual(
             CALLBACK_NEWLENGTH_NULL,
         );
-        expect(e.popUnsubscribe(Events.PlayerConnection)).toStrictEqual(
+        expect(e.unsubscribe(Events.PlayerConnection)).toStrictEqual(
             CALLBACK_NEWLENGTH_NULL,
         );
     });
@@ -130,7 +130,7 @@ describe("Event System Unit Tests", () => {
 
         expect(e.getCallback(Events.GameStart, 2)).toEqual(c3);
 
-        expect(e.popUnsubscribe(Events.GameStart)).toEqual({
+        expect(e.unsubscribe(Events.GameStart)).toEqual({
             callback: c3,
             newLength: 2,
         });
@@ -215,10 +215,10 @@ describe("Event System Unit Tests", () => {
 
         expect(e.getCallback(Events.GameStart, 2)).toEqual(c3);
 
-        expect(e.unsubscribe(Events.GameStart, 4)).toStrictEqual(
+        expect(e.unsubscribeIndex(Events.GameStart, 4)).toStrictEqual(
             CALLBACK_NEWLENGTH_NULL,
         );
-        expect(e.unsubscribe(Events.GameEnd, 0)).toStrictEqual({
+        expect(e.unsubscribeIndex(Events.GameEnd, 0)).toStrictEqual({
             callback: c0,
             newLength: 0,
         });
@@ -239,7 +239,8 @@ describe("Event System Unit Tests", () => {
         expect(consoleSpy).toHaveBeenNthCalledWith(3, l2);
     });
 
-    it("insertSubscribe", async () => {});
+    it("subscribeIndex", async () => {});
+    it("unsubscribeCallback", async () => {});
 });
 
 function sleep(ms: number) {

--- a/src/event/src/event.ts
+++ b/src/event/src/event.ts
@@ -1,24 +1,52 @@
 export class Event<Events, EventsTypes> {
-    private eventsMap = new Map<Events, [(data: EventsTypes) => void]>();
+    private eventsMap = new Map<
+        Events,
+        [
+            {
+                func: (
+                    data: EventsTypes,
+                ) => Promise<void> | ((data: EventsTypes) => void);
+                await: Boolean;
+            },
+        ]
+    >();
 
-    // Returns if the event already has or not a callback
+    /**
+     * hasCallback checks wether the event has any callbacks
+     * @param event Event Type
+     * @returns true if the event already has a callback
+     */
     public hasCallback(event: Events) {
         return this.eventsMap.has(event);
     }
 
-    // Returns the number of callbacks for a given event
+    /**
+     * getNumberOfCallbacks returns the number of callbacks
+     * @param event Event Type
+     * @returns the number of callbacks
+     */
     public getNumberOfCallbacks(event: Events): number {
         if (!this.hasCallback(event)) {
             return 0;
         }
 
         let eCallbacks = this.eventsMap.get(event) as [
-            (data: EventsTypes) => void,
+            {
+                func: (
+                    data: EventsTypes,
+                ) => Promise<void> | ((data: EventsTypes) => void);
+                await: Boolean;
+            },
         ];
         return eCallbacks.length;
     }
 
-    // Returns the callback based on the index
+    /**
+     * getCallback returns the callback based on the index
+     * @param event Event Type
+     * @param index Callback Index
+     * @returns a callback or null
+     */
     public getCallback(event: Events, index: number) {
         if (!this.hasCallback(event)) {
             return null;
@@ -29,59 +57,175 @@ export class Event<Events, EventsTypes> {
         }
 
         let eCallbacks = this.eventsMap.get(event) as [
-            (data: EventsTypes) => void,
+            {
+                func: (
+                    data: EventsTypes,
+                ) => Promise<void> | ((data: EventsTypes) => void);
+                await: Boolean;
+            },
         ];
         return eCallbacks[index];
     }
 
-    // Subscribes a callback to an event, returns the callback index
+    /**
+     * subscribe appends a callback to the given event type
+     * @param event Event Type
+     * @param callback Callback Function
+     * @param await If awaits for asynchrronous callback, defaults to false
+     * @returns the index of the subscribed callback
+     */
     public subscribe(
         event: Events,
-        callback: (data: EventsTypes) => void,
+        callback: (
+            data: EventsTypes,
+        ) => Promise<void> | ((data: EventsTypes) => void),
+        await: Boolean = false,
     ): number {
+        let clb = {
+            func: callback,
+            await: await,
+        };
+
+        if (clb.await != true || clb.constructor.name !== "AsyncFunction") {
+            clb.await = false;
+        }
+
         if (!this.hasCallback(event)) {
-            this.eventsMap.set(event, [callback]);
+            this.eventsMap.set(event, [clb]);
             return 0;
         }
 
         let callbacks = this.eventsMap.get(event) as [
-            (data: EventsTypes) => void,
+            {
+                func: (
+                    data: EventsTypes,
+                ) => Promise<void> | ((data: EventsTypes) => void);
+                await: Boolean;
+            },
         ];
-        let index = callbacks.push(callback) - 1;
+        let index = callbacks.push(clb) - 1;
         this.eventsMap.set(event, callbacks);
         return index;
     }
 
-    // Throws the event by calling each callback subscribed to it,
-    // from first to last subscribed
+    /**
+     * subscribeIndex insert a callback to the given event type, appends the callback
+     * (subscribe) if the index is out of bound
+     * @param event Event Type
+     * @param index Index to insert at
+     * @param callback Callback Function
+     * @param await If awaits for asynchrronous callback, defaults to false
+     * @returns the index of the subscribed callback,
+     */
+    public subscribeIndex(
+        event: Events,
+        index: number,
+        callback: (
+            data: EventsTypes,
+        ) => Promise<void> | ((data: EventsTypes) => void),
+        await: Boolean = false,
+    ): number {
+        let clb = {
+            func: callback,
+            await: await,
+        };
+
+        if (
+            !this.hasCallback(event) ||
+            this.getNumberOfCallbacks(event) <= index
+        ) {
+            return this.subscribe(event, callback, await);
+        }
+
+        if (clb.await != true || clb.constructor.name !== "AsyncFunction") {
+            clb.await = false;
+        }
+
+        let callbacks = this.eventsMap.get(event) as [
+            {
+                func: (
+                    data: EventsTypes,
+                ) => Promise<void> | ((data: EventsTypes) => void);
+                await: Boolean;
+            },
+        ];
+
+        let previousPreviousCallback = callbacks[index];
+        callbacks[index] = clb;
+        for (let i = index + 1; i <= callbacks.length; ++i) {
+            if (i == callbacks.length) {
+                callbacks.push(previousPreviousCallback);
+                break;
+            }
+
+            let previousCallback = callbacks[i];
+            callbacks[i] = previousPreviousCallback;
+            previousPreviousCallback = previousCallback;
+        }
+
+        this.eventsMap.set(event, callbacks);
+
+        return index;
+    }
+
+    /**
+     * throw throws the event and executes all callbacks, it waits for asynchronous call that have been specified. From first to last
+     * @param event Even Type
+     * @param data Event Data
+     * @returns null if there ar no callbacks, void if there are
+     */
     public throw(event: Events, data: EventsTypes): void | null {
         if (!this.hasCallback(event)) {
             return null;
         }
 
         let callbacks = this.eventsMap.get(event) as [
-            (data: EventsTypes) => void,
+            {
+                func: (
+                    data: EventsTypes,
+                ) => Promise<void> | ((data: EventsTypes) => void);
+                await: Boolean;
+            },
         ];
 
-        callbacks.forEach((c) => {
-            c(data);
+        callbacks.forEach(async (c) => {
+            if (c.await) {
+                await c.func(data);
+                return;
+            }
+
+            c.func(data);
         });
     }
 
-    // Unsubscribes a callback from the event, if the index does not exists
-    // it will return both a null callback in new index.
-    public unsubscribe(event: Events, index: number) {
+    /**
+     * unsubscribeIndex unsubscribe a callback to the given event type at the given index
+     * @param event Event Type
+     * @param index Index to insert at
+     * @param callback Callback Function
+     * @param await If awaits for asynchronous callback, defaults to false
+     * @returns callback and the new callbacks length, if the index is out of bound returns
+     * both the callback and the length as null
+     */
+    public unsubscribeIndex(event: Events, index: number) {
         if (!this.hasCallback(event)) {
             return { callback: null as null, newLength: null as null };
         }
 
         let callbacks = this.eventsMap.get(event) as [
-            (data: EventsTypes) => void,
+            {
+                func: (
+                    data: EventsTypes,
+                ) => Promise<void> | ((data: EventsTypes) => void);
+                await: Boolean;
+            },
         ];
         let newLength: number | null = null;
 
-        let unsubscribedCallback: { (data: EventsTypes): void } | null =
-            index >= callbacks.length ? null : callbacks[index];
+        let unsubscribedCallback:
+            | { func: (data: EventsTypes) => void; await: Boolean }
+            | { func: (data: EventsTypes) => Promise<void>; await: Boolean }
+            | null = index >= callbacks.length ? null : callbacks[index];
         if (unsubscribedCallback != null) {
             for (let i = index; i < callbacks.length - 1; ++i) {
                 callbacks[i] = callbacks[i + 1];
@@ -95,15 +239,43 @@ export class Event<Events, EventsTypes> {
         return { callback: unsubscribedCallback, newLength: newLength };
     }
 
-    // Unsubscribes the last callback added to an event, returns
-    // it and the new length of the callbacks
-    public popUnsubscribe(event: Events) {
+    /**
+     * unsubscribe pops the last callback of the Event
+     * @param event Event Type
+     * @returns the callback and the new callbacks length, if there are none it returns
+     * both as null
+     */
+    public unsubscribeCallback(
+        event: Events,
+        callback: (
+            data: EventsTypes,
+        ) => Promise<void> | ((data: EventsTypes) => void),
+    ) {
+        if (!this.hasCallback(event)) {
+            return { callback: null as null, newLength: null as null };
+        }
+
+        return { callback: null, newLength: null };
+    }
+
+    /**
+     * unsubscribe pops the last callback of the Event
+     * @param event Event Type
+     * @returns the callback and the new callbacks length, if there are none it returns
+     * both as null
+     */
+    public unsubscribe(event: Events) {
         if (!this.hasCallback(event)) {
             return { callback: null as null, newLength: null as null };
         }
 
         let callbacks = this.eventsMap.get(event) as [
-            (data: EventsTypes) => void,
+            {
+                func: (
+                    data: EventsTypes,
+                ) => Promise<void> | ((data: EventsTypes) => void);
+                await: Boolean;
+            },
         ];
         let newLength = callbacks.length - 1;
         let callback = callbacks.pop();
@@ -112,7 +284,10 @@ export class Event<Events, EventsTypes> {
         return { callback: callback, newLength: newLength };
     }
 
-    // Completely clears an event callbacks
+    /**
+     * clear the event completely from callbacks
+     * @param event Event Type
+     */
     public clear(event: Events) {
         this.eventsMap.delete(event);
     }

--- a/src/event/src/event.ts
+++ b/src/event/src/event.ts
@@ -79,14 +79,14 @@ export class Event<Events, EventsTypes> {
         callback: (
             data: EventsTypes,
         ) => Promise<void> | ((data: EventsTypes) => void),
-        wait: Boolean = false,
+        wait: Boolean = true,
     ): number {
         let clb = {
             func: callback,
             wait: wait,
         };
 
-        if (clb.wait != true) {
+        if (clb.wait != true || clb.wait == undefined || clb.wait == null) {
             clb.wait = false;
         }
 
@@ -123,7 +123,7 @@ export class Event<Events, EventsTypes> {
         callback: (
             data: EventsTypes,
         ) => Promise<void> | ((data: EventsTypes) => void),
-        wait: Boolean = false,
+        wait: Boolean = true,
     ): number {
         if (
             !this.hasCallback(event) ||
@@ -137,7 +137,7 @@ export class Event<Events, EventsTypes> {
             wait: wait,
         };
 
-        if (clb.wait != true) {
+        if (clb.wait != true || clb.wait == undefined || clb.wait == null) {
             clb.wait = false;
         }
 
@@ -318,7 +318,7 @@ export class Event<Events, EventsTypes> {
      * unsubscribeAllCallback eliminates all callbacks that match the desired from
      * the Event
      * @param event Event Type
-     * @param callback Callback Function to eliminate
+     * @param callback Callback Function to unsubscribe
      * @returns the callback and the new callbacks length, if there are none it returns
      * both as null
      */
@@ -332,20 +332,39 @@ export class Event<Events, EventsTypes> {
             return { callback: null as null, newLength: null as null };
         }
 
-        let callbacks = this.eventsMap.get(event) as [
-            {
-                func: (
-                    data: EventsTypes,
-                ) => Promise<void> | ((data: EventsTypes) => void);
-                wait: Boolean;
-            },
-        ];
-
-        let counter: number = 0;
-        let tail: number = 0;
-        let head: number = 0;
-
-        // implement
+        // Can be improved
+        let elementeleminated:
+            | {
+                  callback: {
+                      func: (
+                          data: EventsTypes,
+                      ) => Promise<void> | ((data: EventsTypes) => void);
+                      wait: Boolean;
+                  };
+                  newLength: number;
+              }
+            | { callback: null; newLength: null }
+            | null = null;
+        while (
+            elementeleminated == null ||
+            elementeleminated.callback?.func == callback
+        ) {
+            elementeleminated = this.unsubscribeFirstCallback(
+                event,
+                callback,
+            ) as
+                | {
+                      callback: {
+                          func: (
+                              data: EventsTypes,
+                          ) => Promise<void> | ((data: EventsTypes) => void);
+                          wait: Boolean;
+                      };
+                      newLength: number;
+                  }
+                | { callback: null; newLength: null }
+                | null;
+        }
     }
 
     /**

--- a/src/event/src/event.ts
+++ b/src/event/src/event.ts
@@ -208,7 +208,10 @@ export class Event<Events, EventsTypes> {
      * both the callback and the length as null
      */
     public unsubscribeIndex(event: Events, index: number) {
-        if (!this.hasCallback(event)) {
+        if (
+            !this.hasCallback(event) ||
+            index >= this.getNumberOfCallbacks(event)
+        ) {
             return { callback: null as null, newLength: null as null };
         }
 
@@ -221,20 +224,15 @@ export class Event<Events, EventsTypes> {
             },
         ];
         let newLength: number | null = null;
+        let unsubscribedCallback = callbacks[index];
 
-        let unsubscribedCallback:
-            | { func: (data: EventsTypes) => void; await: Boolean }
-            | { func: (data: EventsTypes) => Promise<void>; await: Boolean }
-            | null = index >= callbacks.length ? null : callbacks[index];
-        if (unsubscribedCallback != null) {
-            for (let i = index; i < callbacks.length - 1; ++i) {
-                callbacks[i] = callbacks[i + 1];
-            }
-
-            callbacks.pop();
-            newLength = callbacks.length;
-            this.eventsMap.set(event, callbacks);
+        for (let i = index; i < callbacks.length - 1; ++i) {
+            callbacks[i] = callbacks[i + 1];
         }
+
+        callbacks.pop();
+        newLength = callbacks.length;
+        this.eventsMap.set(event, callbacks);
 
         return { callback: unsubscribedCallback, newLength: newLength };
     }
@@ -254,6 +252,8 @@ export class Event<Events, EventsTypes> {
         if (!this.hasCallback(event)) {
             return { callback: null as null, newLength: null as null };
         }
+
+        // implement
 
         return { callback: null, newLength: null };
     }

--- a/src/event/src/event.ts
+++ b/src/event/src/event.ts
@@ -281,8 +281,6 @@ export class Event<Events, EventsTypes> {
             data: EventsTypes,
         ) => Promise<void> | ((data: EventsTypes) => void),
     ) {
-        // Broken
-
         if (!this.hasCallback(event)) {
             return { callback: null as null, newLength: null as null };
         }
@@ -299,7 +297,7 @@ export class Event<Events, EventsTypes> {
         let index: number | null = null;
 
         for (let i = 0; i < callbacks.length; i++) {
-            if (callbacks[i].func == callback) {
+            if (callbacks[i].func === callback) {
                 index = i;
                 break;
             }
@@ -309,7 +307,7 @@ export class Event<Events, EventsTypes> {
             return { callback: null, newLength: null };
         }
 
-        for (let i = 0; i < callbacks.length - 1; i++) {
+        for (let i = index; i < callbacks.length - 1; i++) {
             callbacks[i] = callbacks[i + 1];
         }
 


### PR DESCRIPTION
## Description
Changes made to the event system to be able to handle async functions execution.

This introduces a new method for throwing events. Note that this update is retro compatible, as the old `throw` interface has not been modified:
'throw' will throw each callback in an synchronous way, meaning you won't be able to wait for callbacks to finish.
`throwAsync` will throw each callback asynchronously (based on callback wait flag). You can await for `throwAsync` to finish.

Callback wait flag:
When subscribing a callback with any subscribe functions (`subscribe` or `subscribeIndex`) there is the option to pass an additional value `wait`, which if passed as any other value except for true it will modify the callback priority and it won't be awaited when calling `throwAsync`, if `wait` is not passed in it will default to `true` and the callback will be waited when calling `throwAsync`.

Important and breaking changes:
`popUnsubscribe` has been substituted by `unsubscribe`.
`unsubscribe`, has been substituted by 'unsubscribeIndex'.
added `subscribeIndex`, that subscribes a callback in the given index position, if it overflows it will append the callback (same as `subscribe`).
added `unsubscribeFirstCallback`, that eliminates the first callback equal to the given callback.
added `unsubscribeAllCallback`, that eliminates all callbacks equal to the given callback.

Added better and more useful functions definitions, that appear in IDEs.

## Motivation and Context
We can't limit the event system to have only synchronous functions, as in the future there will be need for asynchronous functions to be run during an event emission

## Related PRs
no related PRs

## How Has This Been Tested?
I did unit tests for both, updated functions and new methods.

The component has been tested by unit testing with jest, if you wish to see the test, they are inside the folder `app/src/event/src/__test__`.

You can run them with:
```sh
cd src/event
npm i
npm run test
npm run coverage
```